### PR TITLE
ci: add github action to confirm Dockerfile still works on any PR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,48 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-build.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-build.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build Docker image
+      run: docker build . --file Dockerfile --tag birdnet:local-test
+
+    # Optional: Add basic test to verify the image works
+    - name: Test Docker image
+      run: |
+        docker run -v $PWD/birdnet_analyzer/example:/audio birdnet:local-test -m birdnet_analyzer.analyze --i /audio --o /audio --slist /audio
+        
+        # Verify output file content
+        expected_header="Selection	View	Channel	Begin Time (s)	End Time (s)	Low Freq (Hz)	High Freq (Hz)	Common Name	Species Code	Confidence	Begin Path	File Offset (s)"
+        expected_first_line="1	Spectrogram 1	1	0	3.0	0	15000	Black-capped Chickadee	bkcchi	0.8141	/audio/soundscape.wav	0"
+        
+        actual_header=$(head -n 1 birdnet_analyzer/example/soundscape.BirdNET.selection.table.txt)
+        actual_first_line=$(head -n 2 birdnet_analyzer/example/soundscape.BirdNET.selection.table.txt | tail -n 1)
+        
+        if [ "$actual_header" != "$expected_header" ] || [ "$actual_first_line" != "$expected_first_line" ]
+        then
+            echo "Output file content does not match expected content"
+            echo "Expected header: $expected_header"
+            echo "Actual header: $actual_header"
+            echo "Expected first line: $expected_first_line"
+            echo "Actual first line: $actual_first_line"
+            exit 1
+        else
+            echo "test received expected output file contents"
+        fi

--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ image:{os-badge}[Supported OS, link=""]
 image:{species-badge}[Number of species, link=""]
 image:{downloads-badge}[Downloads, link=""]
 // build badge
-image:https://github.com/kenshih/BirdNET-Analyzer/actions/workflows/docker-build.yml/badge.svg[Docker Build, link="https://github.com/kenshih/BirdNET-Analyzer/actions/workflows/docker-build.yml"]
+image:https://github.com/kahst/BirdNET-Analyzer/actions/workflows/docker-build.yml/badge.svg[Docker Build, link="https://github.com/kahst/BirdNET-Analyzer/actions/workflows/docker-build.yml"]
 
 
 [.text-center]

--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,8 @@ image:{license-badge}[CC BY-NC-SA 4.0, link={cc-by-nc-sa}]
 image:{os-badge}[Supported OS, link=""]
 image:{species-badge}[Number of species, link=""]
 image:{downloads-badge}[Downloads, link=""]
+// build badge
+image:https://github.com/kenshih/BirdNET-Analyzer/actions/workflows/docker-build.yml/badge.svg[Docker Build, link="https://github.com/kenshih/BirdNET-Analyzer/actions/workflows/docker-build.yml"]
 
 
 [.text-center]


### PR DESCRIPTION
# Preview version of PR: https://github.com/kahst/BirdNET-Analyzer/pull/536


A simple Github Action that will run on any PR to confirm the docker build and run still work.

Also adds a badge like this [![Docker Build](https://github.com/kenshih/BirdNET-Analyzer/actions/workflows/docker-build.yml/badge.svg)](https://github.com/kenshih/BirdNET-Analyzer/actions/workflows/docker-build.yml) when the `main` branch is passing. That is, it’s running the first docker command, as described in the README.

[e.g.](https://github.com/kenshih/BirdNET-Analyzer/blob/github-action-docker-build/README.adoc)

<img width="786" alt="Screenshot 2024-12-26 at 10 01 12 PM" src="https://github.com/user-attachments/assets/1b39b10c-f0b6-42fc-a614-5fd3e2a393d1" />


